### PR TITLE
Configure Devstral frontend: Remove API key and model selection, hardcode Devstral settings, and update Docker Compose for custom build

### DIFF
--- a/docker-compose.simple.yml
+++ b/docker-compose.simple.yml
@@ -17,7 +17,7 @@ services:
     restart: unless-stopped
 
   openhands:
-    image: docker.all-hands.dev/all-hands-ai/openhands:0.40
+    build: ./openhands-frontend
     container_name: devstral-openhands
     ports:
       - "${OPENHANDS_PORT:-3000}:3000"

--- a/ollama-setup/docker-compose.yml
+++ b/ollama-setup/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 3
 
   openhands:
-    image: docker.all-hands.dev/all-hands-ai/openhands:0.40
+    build: ../openhands-frontend
     container_name: openhands
     ports:
       - "3000:3000"


### PR DESCRIPTION
This PR configures the Devstral frontend by:
- Removing API key input components.
- Removing model selection dropdowns.
- Hardcoding API base URL to `http://ollama:11434/v1`.
- Hardcoding model name to `devstral`.
- Creating a custom Docker build for the patched frontend.
- Updating `docker-compose.simple.yml` and `ollama-setup/docker-compose.yml` to use the custom frontend build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated service configuration to build the OpenHands frontend locally instead of using a pre-built image. This change affects local deployment setup but does not alter application features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->