### PR TITLE
Fix: Ensure Ollama model is created and deployment scripts are consis…

### DIFF
--- a/DOCKER_DEPLOYMENT.md
+++ b/DOCKER_DEPLOYMENT.md
@@ -373,3 +373,9 @@ To contribute to the Docker deployment:
 ## 📄 License
 
 This Docker deployment is part of the Devstral OpenHands project and is licensed under the MIT License.
+
+## Frontend Image for Ollama Deployment
+
+When `DEPLOYMENT_TYPE` is set to `ollama` (the default), the system uses the configuration from `examples/quick-start-ollama.yml`. This configuration specifies a pre-built Docker image for the OpenHands frontend service (e.g., `docker.all-hands.dev/all-hands-ai/openhands:0.40`).
+
+The `docker-compose.simple.yml` file contains a definition to build the `openhands` service from a local `./openhands-frontend` directory. However, for the `ollama` deployment type, this local build definition is NOT used by the main `entrypoint.sh` script. Ensure that if you intend to modify the frontend, you should either rebuild the pre-built image and update the tag in `examples/quick-start-ollama.yml`, or adapt the deployment scripts if you require a local build for `ollama` mode.

--- a/Dockerfile
+++ b/Dockerfile
@@ -198,18 +198,18 @@ start_services() {
     
     # Pull images
     print_status "Pulling Docker images..."
-    docker compose -f docker-compose.simple.yml pull
+    docker compose -f docker-compose.yml pull
     
     # Start services
     print_status "Starting containers..."
-    docker compose -f docker-compose.simple.yml up -d
+    docker compose -f docker-compose.yml up -d
     
     # Wait for services to be ready
     print_status "Waiting for services to start..."
     sleep 15
     
     # Check service status
-    if docker compose -f docker-compose.simple.yml ps | grep -q "Up"; then
+    if docker compose -f docker-compose.yml ps | grep -q "Up"; then
         print_success "Services started successfully!"
         
         # Additional setup for Ollama
@@ -218,11 +218,11 @@ start_services() {
             sleep 10  # Wait for Ollama to be fully ready
             
             # Copy Modelfile and create model
-            docker cp ./Modelfile $(docker compose -f docker-compose.simple.yml ps -q ollama):/tmp/ 2>/dev/null || true
-            docker exec $(docker compose -f docker-compose.simple.yml ps -q ollama) ollama create ${MODEL_NAME} -f /tmp/Modelfile 2>/dev/null || {
+            docker cp ./Modelfile $(docker compose -f docker-compose.yml ps -q ollama):/tmp/ 2>/dev/null || true
+            docker exec $(docker compose -f docker-compose.yml ps -q ollama) ollama create ${MODEL_NAME} -f /tmp/Modelfile 2>/dev/null || {
                 print_warning "Could not automatically create Ollama model."
                 print_status "You may need to manually run:"
-                print_status "docker exec -it \$(docker compose -f docker-compose.simple.yml ps -q ollama) ollama create ${MODEL_NAME} -f /tmp/Modelfile"
+                print_status "docker exec -it \$(docker compose -f docker-compose.yml ps -q ollama) ollama create ${MODEL_NAME} -f /tmp/Modelfile"
             }
         fi
         
@@ -243,11 +243,11 @@ start_services() {
                 ;;
         esac
         echo
-        print_status "Logs can be viewed with: docker compose -f docker-compose.simple.yml logs -f"
+        print_status "Logs can be viewed with: docker compose -f docker-compose.yml logs -f"
         
     else
-        print_error "Some services failed to start. Check logs with: docker compose -f docker-compose.simple.yml logs"
-        docker compose -f docker-compose.simple.yml logs
+        print_error "Some services failed to start. Check logs with: docker compose -f docker-compose.yml logs"
+        docker compose -f docker-compose.yml logs
         exit 1
     fi
 }
@@ -255,7 +255,7 @@ start_services() {
 # Function to show logs
 show_logs() {
     print_status "Showing service logs..."
-    docker compose -f docker-compose.simple.yml logs -f
+    docker compose -f docker-compose.yml logs -f
 }
 
 # Main execution
@@ -290,18 +290,18 @@ case "${1:-start}" in
         main
         ;;
     "logs")
-        docker compose -f docker-compose.simple.yml logs -f
+        docker compose -f docker-compose.yml logs -f
         ;;
     "stop")
         print_status "Stopping services..."
-        docker compose -f docker-compose.simple.yml down
+        docker compose -f docker-compose.yml down
         ;;
     "restart")
         print_status "Restarting services..."
-        docker compose -f docker-compose.simple.yml restart
+        docker compose -f docker-compose.yml restart
         ;;
     "status")
-        docker compose -f docker-compose.simple.yml ps
+        docker compose -f docker-compose.yml ps
         ;;
     "shell")
         /bin/bash

--- a/ollama-setup/Modelfile
+++ b/ollama-setup/Modelfile
@@ -1,7 +1,7 @@
 # Modelfile for Devstral
 # This file defines how to create a Devstral model in Ollama from a GGUF file
 
-FROM ./devstral-model.gguf
+FROM /models/devstral-model.gguf
 
 # Set the template for the model
 TEMPLATE """{{ if .System }}<|im_start|>system


### PR DESCRIPTION
…tent

This commit addresses an issue where the application would incorrectly prompt for an API key and model name when you deployed it with Ollama.

The primary reasons were:
1. The Modelfile used a relative path (`FROM ./model.gguf`) for the base model, which failed when `ollama create` was executed in a different working directory inside the container. I've changed this to an absolute path (`FROM /models/model.gguf`).
2. The main `entrypoint.sh` script was inconsistently using `docker-compose.simple.yml` for some operations (like `pull`, `up`, and `ollama create` targeting) even when it had copied `examples/quick-start-ollama.yml` to `docker-compose.yml` for the active configuration. I've updated the script to consistently use `docker-compose.yml`.

Additionally, I've added documentation in `DOCKER_DEPLOYMENT.md` to clarify that for `DEPLOYMENT_TYPE=ollama`, a pre-built frontend image is used, bypassing any local build instructions in `docker-compose.simple.yml`.